### PR TITLE
Truncate css fix

### DIFF
--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -96,4 +96,7 @@
 .source-footer .mapped-source {
   color: var(--theme-body-color);
   padding: 2.5px;
+  white-space: nowrap; 
+  overflow: hidden; 
+  text-overflow: ellipsis; 
 }

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -96,7 +96,7 @@
 .source-footer .mapped-source {
   color: var(--theme-body-color);
   padding: 2.5px;
-  white-space: nowrap; 
-  overflow: hidden; 
-  text-overflow: ellipsis; 
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -33,7 +33,7 @@
 }
 
 .source-tabs {
-  width: calc(100% - 80px); 
+  width: calc(100% - 80px);
   align-self: flex-start;
 }
 
@@ -50,7 +50,7 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  min-width: 25%; 
+  min-width: 25%;
   max-width: 30%;
 }
 

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -33,7 +33,7 @@
 }
 
 .source-tabs {
-  max-width: calc(100% - 80px);
+  width: 25%;
   align-self: flex-start;
 }
 
@@ -51,6 +51,7 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
+  width: 100%; 
 }
 
 .source-tab:first-child {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -33,7 +33,7 @@
 }
 
 .source-tabs {
-  width: 25%;
+  width: calc(100% - 80px); 
   align-self: flex-start;
 }
 
@@ -45,13 +45,13 @@
   align-items: center;
   position: relative;
   transition: all 0.15s ease;
-  min-width: 40px;
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  width: 100%;
+  min-width: 25%; 
+  max-width: 30%;
 }
 
 .source-tab:first-child {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -50,7 +50,6 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  min-width: 25%;
   max-width: 30%;
 }
 

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -51,7 +51,7 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  width: 100%; 
+  width: 100%;
 }
 
 .source-tab:first-child {

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -385,6 +385,7 @@ class SourceTabs extends PureComponent<Props, State> {
         onContextMenu={e => this.onTabContextMenu(e, source)}
         title={tabName(source)}
       >
+        {sourceAnnotation}
         <div className="filename">{tabName(source)}</div>
         <CloseButton
           handleClick={onClickClose}
@@ -422,7 +423,7 @@ class SourceTabs extends PureComponent<Props, State> {
         onContextMenu={e => this.onTabContextMenu(e, source.get("id"))}
         title={getFileURL(source.toJS())}
       >
-        {sourceAnnotation}
+        {}
         <div className="filename">{filename}</div>
         <CloseButton
           handleClick={onClickClose}

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -385,7 +385,6 @@ class SourceTabs extends PureComponent<Props, State> {
         onContextMenu={e => this.onTabContextMenu(e, source)}
         title={tabName(source)}
       >
-        {sourceAnnotation}
         <div className="filename">{tabName(source)}</div>
         <CloseButton
           handleClick={onClickClose}
@@ -403,7 +402,6 @@ class SourceTabs extends PureComponent<Props, State> {
       source.get("id") == selectedSource.get("id") &&
       (!this.isProjectSearchEnabled() && !this.isSourceSearchEnabled());
     const isPrettyCode = isPretty(source);
-    const sourceAnnotation = this.getSourceAnnotation(source);
 
     function onClickClose(ev) {
       ev.stopPropagation();

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -20,7 +20,6 @@ import {
   getTopFrame
 } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
-// import { endTruncateStr } from "../../utils/utils";
 import { getFilename } from "../../utils/source";
 import { isInterrupted } from "../../utils/pause";
 import CloseButton from "../shared/Button/Close";

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -20,7 +20,7 @@ import {
   getTopFrame
 } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
-//import { endTruncateStr } from "../../utils/utils";
+// import { endTruncateStr } from "../../utils/utils";
 import { getFilename } from "../../utils/source";
 import { isInterrupted } from "../../utils/pause";
 import CloseButton from "../shared/Button/Close";

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -20,7 +20,7 @@ import {
   getTopFrame
 } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
-import { endTruncateStr } from "../../utils/utils";
+//import { endTruncateStr } from "../../utils/utils";
 import { getFilename } from "../../utils/source";
 import { isInterrupted } from "../../utils/pause";
 import CloseButton from "../shared/Button/Close";
@@ -70,8 +70,7 @@ function getBreakpointFilename(source) {
 function renderSourceLocation(source, line, column) {
   const filename = getBreakpointFilename(source);
   const isWasm = source && source.get("isWasm");
-  const columnVal =
-    features.columnBreakpoints && column ? `:${column}` : "";
+  const columnVal = features.columnBreakpoints && column ? `:${column}` : "";
   const bpLocation = isWasm
     ? `0x${line.toString(16).toUpperCase()}`
     : `${line}${columnVal}`;
@@ -80,11 +79,7 @@ function renderSourceLocation(source, line, column) {
     return null;
   }
 
-  return (
-    <div className="location">
-      {`${endTruncateStr(filename, 30)}: ${bpLocation}`}
-    </div>
-  );
+  return <div className="location">{`${filename}: ${bpLocation}`}</div>;
 }
 
 class Breakpoints extends PureComponent<Props> {

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -43,7 +43,7 @@ function FrameLocation({ frame }: FrameLocationProps) {
   const filename = getFilename(frame.source);
   return (
     <div className="location" title={"Line number:" + frame.location.line}>
-      <div className="fileName">{filename}</div>
+      <div className="fileName">{filename}: </div>
       <div className="lineNumber">{frame.location.line}</div>
     </div>
   );

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -42,7 +42,7 @@ function FrameLocation({ frame }: FrameLocationProps) {
 
   const filename = getFilename(frame.source);
   return (
-    <div title={filename} className="location">
+    <div className="location">
       <div className="fileName">{filename}</div>
       <div className="lineNumber">{frame.location.line}</div>
     </div>
@@ -122,7 +122,6 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         key={frame.id}
         className={className}
         onMouseDown={e => this.onMouseDown(e, frame, selectedFrame)}
-        onMouseOver={e => this.onMouseOver(e, frame)}
         onKeyUp={e => this.onKeyUp(e, frame, selectedFrame)}
         onContextMenu={e => this.onContextMenu(e)}
         tabIndex={0}

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -42,7 +42,10 @@ function FrameLocation({ frame }: FrameLocationProps) {
 
   const filename = getFilename(frame.source);
   return (
-    <div className="location">{`${filename}: ${frame.location.line}`}</div>
+    <div title={filename} className="location">
+      <div className="fileName">{filename}</div>
+      <div className="lineNumber">{frame.location.line}</div>
+    </div>
   );
 }
 
@@ -103,6 +106,9 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     }
     this.props.selectFrame(frame);
   }
+  onMouseOver(e, frame) {
+    console.log(frame.sourceUrl);
+  }
 
   render() {
     const {
@@ -120,6 +126,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         key={frame.id}
         className={className}
         onMouseDown={e => this.onMouseDown(e, frame, selectedFrame)}
+        onMouseOver={e => this.onMouseOver(e, frame)}
         onKeyUp={e => this.onKeyUp(e, frame, selectedFrame)}
         onContextMenu={e => this.onContextMenu(e)}
         tabIndex={0}

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -42,7 +42,7 @@ function FrameLocation({ frame }: FrameLocationProps) {
 
   const filename = getFilename(frame.source);
   return (
-    <div className="location">
+    <div className="location" title={"Line number:" + frame.location.line}>
       <div className="fileName">{filename}</div>
       <div className="lineNumber">{frame.location.line}</div>
     </div>

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -106,10 +106,6 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     }
     this.props.selectFrame(frame);
   }
-  onMouseOver(e, frame) {
-    console.log(frame.sourceUrl);
-  }
-
   render() {
     const {
       frame,

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -39,11 +39,6 @@
   overflow: hidden;
 }
 
-.lineNumber {
-  border-left: 100% solid grey; 
-  border-right: 100% solid grey; 
-}
-
 .theme-light .frames .location,
 .theme-firebug .frames .location {
   color: var(--theme-comment);

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -39,14 +39,13 @@
   overflow: hidden;
 }
 
-.fileLocation{
-  overflow: hidden; 
-  text-overflow: ellipsis; 
+.fileLocation {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-
-.lineNumber{
-  position: fixed; 
+.lineNumber {
+  position: fixed;
 }
 
 .theme-light .frames .location,

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -21,6 +21,7 @@
 .frames ul li * {
   -moz-user-select: none;
   user-select: none;
+  cursor: default; 
 }
 
 .frames .badge {

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -21,7 +21,7 @@
 .frames ul li * {
   -moz-user-select: none;
   user-select: none;
-  cursor: default; 
+  cursor: default;
 }
 
 .frames .badge {

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -36,7 +36,7 @@
   align-items: center;
   margin: 0;
   flex-shrink: 1;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .theme-light .frames .location,
@@ -53,7 +53,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   margin: 7px 0.5em 7px 0;
-  flex-shrink: 0; 
+  flex-shrink: 0;
 }
 
 .frames ul li:hover,

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -39,13 +39,9 @@
   overflow: hidden;
 }
 
-.fileLocation {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .lineNumber {
-  position: fixed;
+  border-left: 100% solid grey; 
+  border-right: 100% solid grey; 
 }
 
 .theme-light .frames .location,

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -39,6 +39,16 @@
   overflow: hidden;
 }
 
+.fileLocation{
+  overflow: hidden; 
+  text-overflow: ellipsis; 
+}
+
+
+.lineNumber{
+  position: fixed; 
+}
+
 .theme-light .frames .location,
 .theme-firebug .frames .location {
   color: var(--theme-comment);

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -35,7 +35,8 @@
   flex-direction: row;
   align-items: center;
   margin: 0;
-  flex-shrink: 0;
+  flex-shrink: 1;
+  overflow: hidden; 
 }
 
 .theme-light .frames .location,
@@ -52,6 +53,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   margin: 7px 0.5em 7px 0;
+  flex-shrink: 0; 
 }
 
 .frames ul li:hover,

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -5,7 +5,6 @@
 // @flow
 
 import { get } from "lodash";
-// import { endTruncateStr } from "./utils";
 import { getFilename } from "./source";
 import { find, findIndex } from "lodash";
 
@@ -203,7 +202,6 @@ export function formatDisplayName(
   }
 
   displayName = simplifyDisplayName(displayName);
-  // return endTruncateStr(displayName, 25);
   return displayName;
 }
 

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { get } from "lodash";
-import { endTruncateStr } from "./utils";
+//import { endTruncateStr } from "./utils";
 import { getFilename } from "./source";
 import { find, findIndex } from "lodash";
 
@@ -203,7 +203,8 @@ export function formatDisplayName(
   }
 
   displayName = simplifyDisplayName(displayName);
-  return endTruncateStr(displayName, 25);
+  // return endTruncateStr(displayName, 25);
+  return displayName;
 }
 
 export function formatCopyName(frame: LocalFrame) {

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { get } from "lodash";
-//import { endTruncateStr } from "./utils";
+// import { endTruncateStr } from "./utils";
 import { getFilename } from "./source";
 import { find, findIndex } from "lodash";
 

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import { endTruncateStr } from "./utils";
+// import { endTruncateStr } from "./utils";
 import { isPretty, getSourcePath, isThirdParty } from "./source";
 
 import type { Location as BabelLocation } from "babel-traverse";
@@ -118,7 +118,7 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100),
+        subtitle: sourcePath,
         id: source.get("id")
       };
     })

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,7 +10,7 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-import { endTruncateStr } from "./utils";
+//import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
@@ -124,7 +124,8 @@ function resolveFileURL(
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
-  return endTruncateStr(name, 50);
+  //return endTruncateStr(name, 50);
+  return name;
 }
 
 export function getFilenameFromURL(url: string) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,7 +10,6 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-// import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
@@ -124,7 +123,6 @@ function resolveFileURL(
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
-  // return endTruncateStr(name, 50);
   return name;
 }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,7 +10,7 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-//import { endTruncateStr } from "./utils";
+// import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
@@ -124,7 +124,7 @@ function resolveFileURL(
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
-  //return endTruncateStr(name, 50);
+  // return endTruncateStr(name, 50);
   return name;
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,12 +38,12 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-function endTruncateStr(str: any, size: number) {
+/*function endTruncateStr(str: any, size: number) {
   if (str.length > size) {
     return `...${str.slice(str.length - size)}`;
   }
   return str;
-}
+}*/
 
 /**
  * @memberof utils/utils
@@ -70,4 +70,4 @@ function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { handleError, promisify, endTruncateStr, throttle, waitForMs };
+export { handleError, promisify, throttle, waitForMs };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,7 +38,7 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-/*function endTruncateStr(str: any, size: number) {
+/* function endTruncateStr(str: any, size: number) {
   if (str.length > size) {
     return `...${str.slice(str.length - size)}`;
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,21 +38,6 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-/* function endTruncateStr(str: any, size: number) {
-  if (str.length > size) {
-    return `...${str.slice(str.length - size)}`;
-  }
-  return str;
-}*/
-
-/**
- * @memberof utils/utils
- * @static
- */
-/**
- * @memberof utils/utils
- * @static
- */
 function throttle(func: any, ms: number) {
   let timeout, _this;
   return function(...args: any) {


### PR DESCRIPTION


Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Change

This fix truncates location names if the location string expands beyond the default width of an element. I eventually found a utility function (endTruncateStr) to be unnecessary, and may hamper future development. This fix replaces that utility function, wherever present, with CSS (text-overflow: ellipsis, except for the frames within callstack-pane), which fixes both issues. 

I haven't found a solution for truncating (with ellipsis) of the frames within callstack-pane. This fix does hide/reveal more of the location strings within that element upon pane resizing.

### Test Plan

Dynamic truncation checklist: 
[x] Upon hitting a breakpoint, locations that expand beyond an element's width should be truncated. 
[x] Pane resizing should increase/decrease the visibility of the location string when increasing/decreasing pane width (dynamic truncation).  

### Screenshots/Videos (OPTIONAL)

<img width="1280" alt="screen shot 2018-01-25 at 7 49 19 pm" src="https://user-images.githubusercontent.com/24966772/35477874-9bc20936-0393-11e8-8663-6c8aa537ee93.png">

<img width="1280" alt="screen shot 2018-01-25 at 7 33 07 pm" src="https://user-images.githubusercontent.com/24966772/35477875-a2d8fb3a-0393-11e8-859a-26121d8a52d0.png">

And with chrome: 

<img width="1280" alt="screen shot 2018-01-27 at 6 58 33 pm" src="https://user-images.githubusercontent.com/24966772/35477899-221ebdbc-0394-11e8-92b0-ea504d5bf65e.png">

<img width="1280" alt="screen shot 2018-01-27 at 6 58 24 pm" src="https://user-images.githubusercontent.com/24966772/35477900-240b3150-0394-11e8-900c-1111e6abf736.png">


